### PR TITLE
[WIP] - APPROACH CHECK-IN - v1 progress

### DIFF
--- a/lib/bulk-timer.js
+++ b/lib/bulk-timer.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = (time, fn) => new Timer(time, fn)
 
 class Timer {

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -18,7 +18,7 @@ class PeerInfo {
     this.status = RECONNECT | FIREWALLED
     this.retries = 0
     this.peer = peer || null
-    this.client = !!peer
+    this.client = peer !== null
     this.stream = null
 
     this._index = 0

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -32,6 +32,10 @@ class PeerInfo {
     return !!(this.status & FIREWALLED)
   }
 
+  get reconnecting () {
+    return !!(this.status & RECONNECT)
+  }
+
   reconnect (val) {
     if (val) this.status |= RECONNECT
     else this.status &= ~RECONNECT

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -32,10 +32,6 @@ class PeerInfo {
     return !!(this.status & FIREWALLED)
   }
 
-  get reconnecting () {
-    return !!(this.status & RECONNECT)
-  }
-
   reconnect (val) {
     if (val) this.status |= RECONNECT
     else this.status &= ~RECONNECT

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = peer => new PeerInfo(peer)
 
 const PROVEN = 0b1

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,4 +1,7 @@
+'use strict'
+
 const spq = require('shuffled-priority-queue')
+const lru = require('hashlru')
 const { EventEmitter } = require('events')
 const peerInfo = require('./peer-info')
 const timer = require('./bulk-timer')
@@ -6,16 +9,18 @@ const timer = require('./bulk-timer')
 module.exports = (opts) => new PeerQueue(opts)
 
 class PeerQueue extends EventEmitter {
-  constructor (opts) {
+  constructor (opts = {}) {
     super()
 
-    if (!opts) opts = {}
+    const {
+      requeue = [ 1000, 5000, 15000 ],
+      cacheSize = 100
+    } = opts
 
     this.destroyed = false
-    this._infos = new Map() // TODO: turn into LRU
+    this._infos = lru(cacheSize)
     this._queue = spq()
 
-    const requeue = opts.requeue || [ 1000, 5000, 15000 ]
     const push = this._push.bind(this)
 
     this._requeue = requeue.map(ms => timer(ms, push))

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const spq = require('shuffled-priority-queue')
-const lru = require('hashlru')
 const { EventEmitter } = require('events')
 const peerInfo = require('./peer-info')
 const timer = require('./bulk-timer')
@@ -13,12 +12,11 @@ class PeerQueue extends EventEmitter {
     super()
 
     const {
-      requeue = [ 1000, 5000, 15000 ],
-      cacheSize = 100
+      requeue = [ 1000, 5000, 15000 ]
     } = opts
 
     this.destroyed = false
-    this._infos = lru(cacheSize)
+    this._infos = new Map()
     this._queue = spq()
 
     const push = this._push.bind(this)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "swarm.js",
   "dependencies": {
     "@hyperswarm/discovery": "^1.1.0",
+    "hashlru": "^2.3.0",
     "shuffled-priority-queue": "^2.1.0",
     "tap": "^13.1.2",
     "utp-native": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "swarm.js",
   "dependencies": {
     "@hyperswarm/discovery": "^1.1.0",
-    "hashlru": "^2.3.0",
     "shuffled-priority-queue": "^2.1.0",
     "tap": "^13.1.2",
     "utp-native": "^2.1.3"

--- a/swarm.js
+++ b/swarm.js
@@ -23,10 +23,8 @@ class Swarm extends EventEmitter {
       ephemeral,
       bind: () => this.emit('listening'),
       socket: (socket, isTCP) => {
-        if (this.peers >= this.maxPeers) return
         const info = peerInfo(null)
         info.connected(socket, isTCP)
-        queue.add(info)
         this.emit('connection', socket, info)
       },
       close: () => this.emit('close')

--- a/swarm.js
+++ b/swarm.js
@@ -1,5 +1,6 @@
 'use strict'
 const peerInfo = require('./lib/peer-info')
+const peerQueue = require('./lib/queue')
 const { EventEmitter } = require('events')
 const guts = require('@hyperswarm/guts')
 
@@ -9,21 +10,39 @@ class Swarm extends EventEmitter {
   constructor (opts = {}) {
     super()
     const { bootstrap, ephemeral } = opts
-    this.network = guts({
+    const queue = peerQueue()
+    const network = guts({
       bootstrap,
       ephemeral,
       bind: () => {
         this.emit('listening')
       },
       socket: (socket, isTCP) => {
-        const info = peerInfo(null)
-        info.connected(socket, isTCP)
-        this.emit('connection', socket, info)
+        this._connected(socket, isTCP)
       },
       close: () => {
         this.emit('close')
       }
     })
+    const onConnect = (err, socket, isTCP) => {
+      if (err) return // todo, logging?
+      this._connected(socket, isTCP)
+    }
+    queue.on('readable', () => {
+      var peer = queue.shift()
+      while (peer) {
+        network.connect(peer, onConnect)
+        peer = queue.shift()
+      }
+    })
+    this.emphemeral = ephemeral !== false
+    this.network = network
+    this.queue = queue
+  }
+  _connected (socket, isTCP) {
+    const info = peerInfo(null)
+    info.connected(socket, isTCP)
+    this.emit('connection', socket, info)
   }
   address () {
     return this.network.address()
@@ -31,7 +50,49 @@ class Swarm extends EventEmitter {
   listen (port, cb) {
     this.network.bind(port, cb)
   }
+  join (key, opts = {}) {
+    const { network, ephemeral } = this
 
+    if (Buffer.isBuffer(key) === false) throw Error('KEY REQUIRED')
+
+    const {
+      announce = ephemeral === false
+    } = opts
+    const {
+      lookup = announce === false
+    } = opts
+
+    if (announce === false && lookup === false) return
+
+    network.bind()
+
+    if (announce) network.announce(key)
+    if (lookup) {
+      this.leave(key)
+      const topic = this.lookup(key)
+      topic.on('update', () => this.emit('update'))
+      topic.on('peer', (peer) => {
+        this.emit('peer', peer)
+        this.queue.add(peer)
+      })
+    }
+  }
+  leave (key) {
+    if (Buffer.isBuffer(key) === false) throw Error('KEY REQUIRED')
+
+    const { network } = this
+    const domain = network.discovery._domain(key)
+    const topics = network.discovery._domains.get(domain)
+    for (const topic of topics) {
+      if (Buffer.compare(key, topic.key)) {
+        topic.destroy()
+        break
+      }
+    }
+  }
+  connect (peer, cb) {
+    this.network.connect(peer, cb)
+  }
   destroy (cb) {
     this.network.close(cb)
   }

--- a/swarm.js
+++ b/swarm.js
@@ -84,7 +84,7 @@ class Swarm extends EventEmitter {
     const domain = network.discovery._domain(key)
     const topics = network.discovery._domains.get(domain)
     for (const topic of topics) {
-      if (Buffer.compare(key, topic.key)) {
+      if (Buffer.compare(key, topic.key) === 0) {
         topic.destroy()
         break
       }


### PR DESCRIPTION
initial implementation of the following

* join
* leave
* connect
* ephemeral opt 
* peer-queue integration
* queue lru

tests are passing but anything newly implemented hasn't been checked at all, this PR is intended as a check-in to ensure that the approaches are valid and that peer queue has been correctly understood

key discussion points: 

### leave
the leave method is using discovery caches to find topics - this saves mem but will mean leave is more expensive. I'm assuming for most use cases leave usage would be light, is this assumption correct? If so, we should modify hyperswarm discovery to return a topic for a given key instead of using private apis

### join 
In join I'm aware that discovery can be used to both announce and lookup, and this is more efficient - however we haven't implemented that in guts and I'd rather get something down and tested first. A change to announce+lookup could be made during optimization phase.

Join is making some new assumptions regarding sane option defaults, if the instance is
not ephemeral, `announce` defaults to `true`, otherwise it defaults to `false`. The `lookup`
option defaults to `true` if `announce` is false (same as in v0). 

### ~~hashlru~~

~~I've added https://github.com/dominictarr/hashlru in place of the `Map` in peer queue. 
This is a lightweight and fast LRU, the trade off is that once peer count reaches `LRU_SIZE * 2` then `LRU_SIZE`  amount of peers will be cleared. Is this an acceptable trade off?~~

### peer queue

My understanding of peer queue is that it periodically reprioritises peers based on their connection status. Status is checked via polling, a back-off mechanism using retry count to determine interval duration controls polling. 

It emits a `readable` event when the queue is populated with one or more healthy peers.
Peers can then be shifted in order of priority (which essentially communicates _how_ healthy a peer is).  

Peers are added to the queue when a topic gets a peer event.

My understanding of how to consume peers from the queue is similar to the readable/while approach with node streams, see https://github.com/hyperswarm/network/compare/v1...v1-progress?expand=1#diff-17a266fdf8e53cfbbdd558c38b69cefdR31

Is this the right direction?

The peer queue also has a `remove` method, but I'm not sure where to use this - wouldn't the peer queue be expected to call `remove` on itself once a peer has been banned? Are there other scenarios I'm not seeing where we would need to call remove from `Swarm`?
