### PR TITLE
releasing strategy for unresponsive and banned peers

### DIFF
--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -20,7 +20,6 @@ class PeerInfo {
     this.peer = peer
     this.client = peer !== null
     this.stream = null
-
     this._index = 0
   }
 
@@ -30,6 +29,10 @@ class PeerInfo {
 
   get firewalled () {
     return !!(this.status & FIREWALLED)
+  }
+
+  get banned () {
+    return !!(this.status & BANNED)
   }
 
   reconnect (val) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -4,33 +4,65 @@ const spq = require('shuffled-priority-queue')
 const { EventEmitter } = require('events')
 const peerInfo = require('./peer-info')
 const timer = require('./bulk-timer')
-
+const noop = () => {}
 module.exports = (opts) => new PeerQueue(opts)
+
+const BACKOFF_S = 1000
+const BACKOFF_M = 5000
+const BACKOFF_L = 15000
+const FORGET_UNRESPONSIVE = 7500
+const FORGET_BANNED = Infinity
 
 class PeerQueue extends EventEmitter {
   constructor (opts = {}) {
     super()
 
     const {
-      requeue = [ 1000, 5000, 15000 ]
+      requeue = [ BACKOFF_S, BACKOFF_M, BACKOFF_L ],
+      forget = {
+        unresponsive: FORGET_UNRESPONSIVE,
+        banned: FORGET_BANNED
+      }
     } = opts
+
+    const [
+      s = BACKOFF_S,
+      m = BACKOFF_M,
+      l = BACKOFF_L
+    ] = requeue
+    const backoff = [s, m, l, ...requeue.slice(3)]
+
+    const {
+      unresponsive = FORGET_UNRESPONSIVE,
+      banned = FORGET_BANNED
+    } = forget
 
     this.destroyed = false
     this._infos = new Map()
     this._queue = spq()
 
     const push = this._push.bind(this)
-
-    this._requeue = requeue.map(ms => timer(ms, push))
+    const release = this._release.bind(this)
+    this._requeue = backoff.map(ms => timer(ms, push))
+    this._remove = [unresponsive, banned].map((ms) => {
+      return ms < Infinity
+        ? timer(ms, release)
+        : { push: noop, destroy: noop } // noop for infinite time
+    })
   }
-
+  _release (batch) {
+    for (const info of batch) this.remove(info.peer)
+  }
   _push (batch) {
     const empty = !this._queue.head()
     let readable = false
 
     for (const info of batch) {
       info.active(false)
-      if (!info.update()) continue
+      if (info.update() === false) {
+        this._remove[info.banned ? 1 : 0].push(info)
+        continue
+      }
       this._queue.add(info)
       readable = true
     }
@@ -89,9 +121,8 @@ class PeerQueue extends EventEmitter {
     if (this.destroyed) return
     this.destroyed = true
 
-    for (const timer of this._requeue) {
-      timer.destroy()
-    }
+    for (const timer of this._requeue) timer.destroy()
+    for (const timer of this._remove) timer.destroy()
 
     this._infos = null
     this._queue = null

--- a/swarm.js
+++ b/swarm.js
@@ -27,9 +27,9 @@ class Swarm extends EventEmitter {
       maxClientSockets = MAX_CLIENT_SOCKETS,
       maxPeers = MAX_PEERS,
       bootstrap,
-      ephemeral
+      ephemeral,
+      queue = {}
     } = opts
-    const queue = peerQueue()
 
     const network = guts({
       bootstrap,
@@ -53,8 +53,6 @@ class Swarm extends EventEmitter {
     network.tcp.maxConnections = maxServerSockets
     network.utp.maxConnections = maxServerSockets
 
-    queue.on('readable', this[kDrain](queue))
-
     this.destroyed = false
     this.clientSockets = 0
     this.serverSockets = 0
@@ -68,7 +66,8 @@ class Swarm extends EventEmitter {
     this.ephemeral = ephemeral !== false
 
     this.network = network
-    this[kQueue] = queue
+    this[kQueue] = peerQueue(queue)
+    this[kQueue].on('readable', this[kDrain](this[kQueue]))
   }
   [kDrain] (queue) {
     const onConnect = (info) => (err, socket, isTCP) => {


### PR DESCRIPTION
**NOTE**: This PR is based on #25 - once that is merged this will be much simpler to review

* will write tests once strategy is validated
* defines two "bad peer" types: 
  * unresponsive – retry count was exceeded
  * banned - peer has been banned
* exposes `queue` options at top level 
* adds a new `forget` option to the queue options, where we can define ms wait before removing unresponsive or banned peers. Banned defaults to Infinity - e.g. banned peers are never forgotten by default. 
* tiny bit of refactoring to const
